### PR TITLE
BE-1129 Allow multiline in console for “select”

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -18,6 +18,14 @@
   version = "v1.7.0"
 
 [[projects]]
+  digest = "1:870d441fe217b8e689d7949fef6e43efbc787e50f200cb1e70dbca9204a1d6be"
+  name = "github.com/inconshreveable/mousetrap"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
+  version = "v1.0"
+
+[[projects]]
   digest = "1:c658e84ad3916da105a761660dcaeb01e63416c8ec7bc62256a9b411a05fcd67"
   name = "github.com/mattn/go-colorable"
   packages = ["."]
@@ -45,12 +53,28 @@
   version = "4.0.18"
 
 [[projects]]
+  digest = "1:645cabccbb4fa8aab25a956cbcbdf6a6845ca736b2c64e197ca7cbb9d210b939"
+  name = "github.com/spf13/cobra"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "ef82de70bb3f60c65fb8eebacbb2d122ef517385"
+  version = "v0.0.3"
+
+[[projects]]
+  digest = "1:c1b1102241e7f645bc8e0c22ae352e8f0dc6484b6cb4d132fa9f24174e0119e2"
+  name = "github.com/spf13/pflag"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "298182f68c66c05229eb03ac171abe6e309ee79a"
+  version = "v1.0.3"
+
+[[projects]]
   branch = "master"
-  digest = "1:8775d8a768d9e65e8b659172804aac5db1fc8d563ba766470a6c2698c57c61a7"
+  digest = "1:71f29ade3ca8b29a03a0506acdaddb46060a1f36389ff62b7f873caaeb582b8f"
   name = "golang.org/x/sys"
   packages = ["unix"]
   pruneopts = "UT"
-  revision = "4ed8d59d0b35e1e29334a206d1b3f38b1e5dfb31"
+  revision = "7c4c994c65f702f41ed7d6620a2cb34107576a77"
 
 [solve-meta]
   analyzer-name = "dep"
@@ -60,6 +84,7 @@
     "github.com/fatih/color",
     "github.com/pinpt/go-common/fileutil",
     "github.com/pinpt/go-common/strings",
+    "github.com/spf13/cobra",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/console.go
+++ b/cmd/console.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"log"
 	"os"
+	"path/filepath"
 
 	"github.com/pinpt/go-dremio/console"
 	"github.com/spf13/cobra"
@@ -21,9 +22,9 @@ var consoleCmd = &cobra.Command{
 		username, _ := cmd.Flags().GetString("username")
 		password, _ := cmd.Flags().GetString("password")
 		endpoint, _ := cmd.Flags().GetString("endpoint")
-
+		cwd, _ := os.Getwd()
 		console.SetCredentials(username, password, endpoint)
-
+		console.SetHistoryFile(filepath.Join(cwd, "history.txt"))
 		printPlugin := console.Plugin{
 			Query:       "^logout$",
 			Usage:       "logout",

--- a/console/console.go
+++ b/console/console.go
@@ -66,7 +66,9 @@ func SetHistoryFile(p string) error {
 	if err != nil {
 		return err
 	}
-	_, err = os.Create(historyFile)
+	if !fileutil.FileExists(historyFile) {
+		_, err = os.Create(historyFile)
+	}
 	return err
 }
 


### PR DESCRIPTION
**JIRA:** https://pinpt-hq.atlassian.net/browse/BE-1129

For the console, if we are doing an SQL "select", we should allow multiline, similar to the MySQL console.

After a _select_ statement, the developer will have to end the sentence with a semicolon, otherwise, the cursor will go to the next line until a sentence is ended with a semicolon