### PR TITLE
readme: add missing "go" marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ go get -u github.com/pinpt/go-dremio
 
 Use it like any normal SQL driver.
 
-```
+```go
 db, err := sql.Open("dremio", "https://user:pass@dremio.example.com")
 ```
 


### PR DESCRIPTION
This enables proper syntax highlighting on GitHub.
